### PR TITLE
Fix prometheus integration check

### DIFF
--- a/zipkin-server/src/test/java/zipkin2/server/internal/prometheus/ITZipkinMetrics.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/prometheus/ITZipkinMetrics.java
@@ -78,7 +78,7 @@ public class ITZipkinMetrics {
 
     // ensure we don't track prometheus, UI requests in prometheus
     assertThat(scrape())
-      .doesNotContain("prometheus")
+      .doesNotContain("uri=\"/prometheus")
       .doesNotContain("uri=\"/zipkin")
       .doesNotContain("uri=\"/\"");
   }


### PR DESCRIPTION
Prometheus integration check was matching on prometheus in the application name. Since the test included prometheus in the package it was failing. This change matches on the URI prefix instead of just the name.